### PR TITLE
Changed cube template `GpuTextureFormat`

### DIFF
--- a/src/templates/game/cube-rust/src/lib.rs
+++ b/src/templates/game/cube-rust/src/lib.rs
@@ -178,7 +178,7 @@ impl Guest for Game {
                 entry_point: "main".to_owned(),
                 constants: Vec::new(),
                 targets: vec![GpuColorTargetState {
-                    format: GpuTextureFormat::Bgra8unormsrgb,
+                    format: GpuTextureFormat::Rgba8unormsrgb,
                     blend: Some(GpuBlendState {
                         color: GpuBlendComponent {
                             src_factor: Some(GpuBlendFactor::One),


### PR DESCRIPTION
In the current example, `rune-cli` returns an error. It says that is expected `Rgba8UnormSrgb`, but got `Bgra8UnormSrgb`. I changed it to `Rgba8unormsrgb`, which works.